### PR TITLE
Fix alt text mismatch for mochila images

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
                 </div>
                 <div class="product-gallery">
                     <img src="IMG/mochiceleste.jpg" alt="Mochila impermeable celeste con monedero" class="product-image">
-                    <img src="IMG/celesteatras.jpg" alt="Mochila impermeable rosa con monedero" class="product-image">
-                    <img src="IMG/rosa.jpg" alt="Vista trasera de la mochila impermeable" class="product-image">
+                    <img src="IMG/celesteatras.jpg" alt="Mochila impermeable celeste, vista trasera" class="product-image">
+                    <img src="IMG/rosa.jpg" alt="Mochila impermeable rosa, vista trasera" class="product-image">
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- correct alt descriptions for mochila images so they match each picture

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c8af95c048333bba35bdb457df56f